### PR TITLE
Update for Swift 2.0 beta 5

### DIFF
--- a/undefined.swift
+++ b/undefined.swift
@@ -22,7 +22,7 @@
  * `fatal error: undefined: main.swift, line 131`
  *
  */
-func undefined<T>(_ hint:String="", file:StaticString=__FILE__, line:UWord=__LINE__) -> T {
+func undefined<T>(hint: String = "", file: StaticString = __FILE__, line: UInt = __LINE__) -> T {
     let message = hint == "" ? "" : ": \(hint)"
     fatalError("undefined \(T.self)\(message)", file:file, line:line)
 }


### PR DESCRIPTION
`UWord` has been removed in favor of `UInt`.
